### PR TITLE
Fix links and add env variable descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Gateway's extensible framework.
 
 ## Features
 
-See the [Features page](https://jupyter-entprise-gateway.readthedocs.io/en/latest/features.html) in the 
+See the [Features page](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/features.html) in the 
 documentation for a list of Jupyter Enterprise Gateway features.
 
 ## Installation
 
 Detailed installation instructions are located in the 
-[Getting Started page](https://jupyter-entprise-gateway.readthedocs.io/en/latest/getting-started.html)
+[Getting Started page](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/getting-started.html)
 of the project docs. Here's a quick start using `pip`:
 
 ```bash
@@ -46,17 +46,17 @@ jupyter enterprisegateway --help-all
 # run it with default options
 jupyter enterprisegateway
 ```
-Please check the [Configuration Options page](https://jupyter-entprise-gateway.readthedocs.io/en/latest/config-options.html) 
+Please check the [Configuration Options page](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/config-options.html) 
 for information about the supported options.
 
-## Detailed Overview
+## System Architecture
 
-The [Detailed Overview page](https://jupyter-entprise-gateway.readthedocs.io/en/latest/detailed-overview.html) 
-includes information about Enterprise Gateway's process proxy and launcher frameworks.
+The [System Architecture page](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/system-architecture.html) 
+includes information about Enterprise Gateway's remote kernel, process proxy, and launcher frameworks.
 
 ## Contributing
 
-The [Contribution page](https://jupyter-entprise-gateway.readthedocs.io/en/latest/contrib.html) includes 
+The [Contribution page](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/contrib.html) includes 
 information about how to contribute to Enterprise Gateway along with our roadmap.  While there, you'll want to
-[set up a development environment](https://jupyter-entprise-gateway.readthedocs.io/en/latest/devinstall.html) and check out typical developer tasks.
+[set up a development environment](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/devinstall.html) and check out typical developer tasks.
 

--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -9,8 +9,9 @@ Jupyter Enterprise Gateway adheres to the
 3. Environment variables
 
 Note that because Enterprise Gateway is built on Kernel Gateway, all of the `KernelGatewayApp` options 
-can be specified as `EnterpriseGatewayApp` options.  In addition, the `KG_` prefix of environment 
-variables has also been perserved.
+can be specified as `EnterpriseGatewayApp` options.  In addition, the `KG_` prefix of inherited environment 
+variables has also been preserved, while those variables introduced by Enterprise Gateway will be
+prefixed with `EG_`.
 
 To generate a template configuration file, run the following:
 
@@ -231,24 +232,69 @@ JupyterWebsocketPersonality options
     by default but kernel gateway does not.
 ```
 
+### Supported environment variables:
+```
+  EG_YARN_ENDPOINT=http://localhost:8088/ws/v1/cluster 
+      YARN resource manager endpoint.  This value can also be specified on the 
+      command line via option '--EnterpriseGatewayApp.yarn_endpoint'.  
 
-## Supported Environment Variables (with default values):
+  EG_REMOTE_USER=<enterprise gateway process owner> 
+      The user name with which ssh operations are carried out under.  It is assumed
+      that password-less ssh has been configured across all targetted nodes within 
+      the cluster.  This value can also be specified on the command line via option 
+      '--EnterpriseGatewayApp.remote_user'.  
+
+  EG_REMOTE_PWD=None 
+      The password of the user specified via `EG_REMOTE_USER`.  This should only be 
+      set in situations where password-less ssh cannot be configured.   
+
+  EG_REMOTE_HOSTS=localhost 
+      A comma-separated list of hosts on which DistributedProcessProxy kernels will
+      be launched e.g., host1,host2.  Not bracketing or quoting of hostnames is 
+      required when setting the env variable.  This value can also be specified on 
+      the command line via option '--EnterpriseGatewayApp.remote_hosts', although 
+      bracketing and quoting is required in that case.  
+ 
+  EG_ENABLE_TUNNELING=False 
+      Indicates whether tunneling (via ssh) of the kernel and communication ports
+      is enabled (True) or not (False).  This feature is currently in experimental 
+      stages but we intend to flip the default value to True at some point.  
+        
+  EG_PROXY_LAUNCH_LOG=/tmp/jeg_proxy_launch.log 
+      The log file used during remote kernel launches of `DistributedProcessProxy`
+      based kernels.  This file should be consulted when kernel operations are not 
+      working as expected.  Note that it will contain output from multiple kernels.  
+              
+  EG_KERNEL_LAUNCH_TIMEOUT=30 
+      The time (in seconds) Enterprise Gateway will wait for a kernel's startup 
+      completion status before deeming the startup a failure, at which time a second 
+      startup attempt will take place.  If a second timeout occurs, Enterprise 
+      Gateway will report a failure to the client.  
+```
+The following environment variables may be useful for troubleshooting:
+```
+  EG_SSH_LOG_LEVEL=WARNING 
+      By default, the `paramiko` ssh library is too verbose for its logging.  This
+      value can be adjusted in situations where ssh troubleshooting may be warranted.  
+
+  EG_YARN_LOG_LEVEL=WARNING 
+      By default, the `yarn-api-client` library is too verbose for its logging.  This
+      value can be adjusted in situations where YARN troubleshooting may be warranted.  
+
+  EG_MAX_POLL_ATTEMPTS=10 
+      Polling is used in various places during life-cycle management operations - like 
+      determining if a kernel process is still alive, stopping the process, waiting 
+      for the process to terminate, etc.  As a result, it may be useful to adjust 
+      this value during those kinds of troubleshooting scenarios, although that 
+      should rarely be necessary.  
+
+  EG_POLL_INTERVAL=0.5
+    The interval (in seconds) to wait before checking poll results again.  
+
+  EG_SOCKET_TIMEOUT=5.0 
+    The time (in seconds) the enterprise gateway will wait on its connection
+    file socket waiting on return from a remote kernel launcher.  Upon timeout, the 
+    operation will be retried immediately, until the overall time limit has been exceeded.   
 
 ```
-EG_YARN_ENDPOINT=http://localhost:8088/ws/v1/cluster
-EG_REMOTE_USER=<process owner>
-EG_REMOTE_PWD
-EG_REMOTE_HOSTS=<localhost>
-EG_ENABLE_TUNNELING=False        
-EG_PROXY_LAUNCH_LOG=/tmp/jeg_proxy_launch.log                
-EG_KERNEL_LAUNCH_TIMEOUT=30
-
-# The following Env varaibles may be useful for troubleshooting
-EG_SSH_LOG_LEVEL='WARNING'
-EG_YARN_LOG_LEVEL='WARNING'
-EG_MAX_POLL_ATTEMPTS=Default=10
-EG_POLL_INTERVAL=0.5
-EG_SOCKET_TIMEOUT=5.0     
-```
-
 

--- a/docs/source/contrib.md
+++ b/docs/source/contrib.md
@@ -5,5 +5,5 @@ project please first take a look at the
 [Project Jupyter Contributor Documentation](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html). 
  
  Prior to your contribution, we strongly recommend getting acquainted with Enterprise Gateway by checking 
- out the [Development Workflow](devinstall.html) and [Detailed Overview](detailed-overview.html) pages.
+ out the [Development Workflow](devinstall.html) and [System Architecture](system-architecture.html) pages.
 

--- a/docs/source/devinstall.md
+++ b/docs/source/devinstall.md
@@ -105,20 +105,3 @@ Run the unit test suite.
 ```bash
 make test
 ```
-
-[//]: # ### Integration Testing
-
-[//]: #Integration testing could be a manual procedure, i.e. first open a sample notebook on a web browser
-[//]: #and then run all the codes, get all outputs and compare if the outputs are the same compared to the
-[//]: #sample notebook *ground truth* outputs. However, it is also feasible to do integration testing
-[//]: #programmatically.
-
-[//]: #On a high level, the first step is to parse a notebook as an entity consisted of multiple code messages
-[//]: #(inputs and outputs). Then ask a given Enterprise Gateway service to create (via `POST`) a new kernel
-[//]: #based on the kernel name of the notebook entity, via the REST API e.g.
-[//]: #`http://<Enterprise Gateway Host IP and Port>/api/kernels`. After there is a kernel ID and the new
-[//]: #kernel is ready, for each of the code cell in the notebook entity, a code message needs be sent to
-[//]: #the Enterprise Gateway service via socket API connection, e.g.
-[//]: #`ws://<Enterprise Gateway Host IP and Port>/api/kernels/<kernel ID>/channels`. After all the outputs
-[//]: #are received for a notebook entity, its outputs should be compared with the *ground truth* outputs
-[//]: #on the sample notebook. If there is anything unexpected, the test could be marked as failed.

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -331,3 +331,5 @@ docker run -t --rm \
     -w /tmp/notebooks \
     biginsights/jupyter-nb-nb2kg:dev
 ```
+Note that the KG_HTTP_USER and KG_HTTP_PASS variables are necessary when Enterprise Gateway
+is behind an Apache Knox gateway.

--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -149,10 +149,7 @@ variable list since `KERNEL_ID` is a primary mechanism for associating remote ap
 def poll(self):
 ```
 The `poll()` method is used by the Jupyter framework to determine if the process is still alive.  By default, the 
-framework's heartbeat mechanism calls `poll()` every 3 seconds.  This value can be adjusted via the configuration 
-setting [`KernelRestarter.time_to_dead`](http://jupyter-console.readthedocs.io/en/latest/config_options.html).
-
-This method returns `None` if the process is still running, `False` otherwise (per the `popen()` contract).
+framework's heartbeat mechanism calls `poll()` every 3 seconds.  This method returns `None` if the process is still running, `False` otherwise (per the `popen()` contract).
 
 ```python
 def wait(self):


### PR DESCRIPTION
Some of the links in the README.md and online docs were not correct.
This PR fixes those links and adds descriptions to the supported env
variables.

Fixes #159