### PR TITLE
Minor doc fixups

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -197,7 +197,7 @@ EnterpriseGatewayApp options
     seed by default. (KG_SEED_URI env var)
 --EnterpriseGatewayApp.yarn_endpoint=<Unicode>
     Default: 'http://localhost:8088/ws/v1/cluster'
-    The http url for accessing the Yarn Resource Manager. (EG_YARN_ENDPOINT env
+    The http url for accessing the YARN Resource Manager. (EG_YARN_ENDPOINT env
     var)
 
 NotebookHTTPPersonality options
@@ -232,7 +232,7 @@ JupyterWebsocketPersonality options
     by default but kernel gateway does not.
 ```
 
-### Supported environment variables:
+### Supported environment variables
 ```
   EG_YARN_ENDPOINT=http://localhost:8088/ws/v1/cluster 
       YARN resource manager endpoint.  This value can also be specified on the 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -44,13 +44,13 @@ using `pip`(part of Anaconda) along with its dependencies.
 pip install jupyter_enterprise_gateway
 ```
 
-Similarly, you can use `pip uninstall jupyter_enterprise_gateway` to uninstall
-Jupyter Enterprise Gateway.
-
 At this point, the Jupyter Enterprise Gateway deployment provides local kernel support which is
 fully compatible with Jupyter Kernel Gateway.
 
-
+To uninstall Jupyter Enterprise Gateway...
+```bash
+pip uninstall jupyter_enterprise_gateway
+```
 [//]: # (### Using conda)
 [//]: # ( )
 [//]: # (You can install Jupyter Enterprise Gateway using conda as well.)
@@ -60,6 +60,7 @@ fully compatible with Jupyter Kernel Gateway.
 [//]: # (```)
 [//]: # ( )
 [//]: # (Once installed, you can use the `jupyter` CLI to run the server as shown above.)
+
 
 #### Using a docker-stacks image
 
@@ -127,7 +128,7 @@ jupyter toree install --spark_home="${SPARK_HOME}" --kernel_name="Spark 2.1" --i
 * Update the Apache Toree Kernelspecs
 
 We have provided some customized kernelspecs as part of the Jupyter Enterprise Gateway releases.
-These kernelspecs come pre-configured with Yarn client and/or cluster mode. Please use the steps below
+These kernelspecs come pre-configured with YARN client and/or cluster mode. Please use the steps below
 as an example on how to update/customize your kernelspecs:
 
 ``` Bash
@@ -145,8 +146,6 @@ cp $KERNELS_FOLDER/spark_2.1_scala/lib/*.jar  $KERNELS_FOLDER/spark_2.1_scala_ya
 ### Installing support for Python (IPython kernel)
 
 The IPython kernel comes pre-configured.
-
-### Installing support for R (IRkernel)
 
 ### Installing support for R (IRkernel)
 
@@ -179,12 +178,10 @@ cp -r [ ENTERPRISE_GATEWAY ]/etc/kernel-launchers/R/scripts /usr/local/share/jup
 
 ```
 
+### Installing Required Packages on YARN Worker Nodes
+To support IPython and R kernels, run the following commands on all YARN worker nodes.
 
-
-#### Installing Required Packages on Yarn Worker Nodes
-To support IPython and R kernels, run the following commands on all Yarn worker nodes.
-
-##### Installing Required Packaged for IPython Kernels on Yarn Worker Nodes
+###### IPython Kernels
 ```Bash
 yum -y install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 yum install -y python2-pip.noarch
@@ -199,7 +196,7 @@ pip install ipykernel 'ipython<6.0'
 pip list | grep -E "ipython|ipykernel"
 ```
 
-##### Installing Required Packaged for R Kernels on Yarn Worker Nodes
+###### R Kernels
 ```Bash
 yum install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 yum install -y R git openssl-devel.x86_64 libcurl-devel.x86_64
@@ -225,7 +222,7 @@ tail -F install_packages.Rout
 ls /usr/lib64/R/library/
 ```
 
-#### Starting Enterprise Gateway
+### Starting Enterprise Gateway
 Very few arguments are necessary to minimally start Enterprise Gateway.  The following command 
 could be considered a minimal command:
 
@@ -262,26 +259,26 @@ else
   exit 1
 fi
 ```
-##### Adding modes of distribution
+### Adding modes of distribution
 By default, without kernelspec modifications, all kernels run local to Enterprise Gateway.  This is
 what is referred to as *LocalProcessProxy* mode.  Enterprise Gateway provides two additional modes
 out of the box, which are reflected in modified kernelspec files.  These modes are *YarnClusterProcessProxy*
 and *DistributedProcessProxy*.  The [system architecture](system-architecture.html) page provides more
 details regarding process proxies.
 
-###### YarnClusterProcessProxy
-YarnClusterProcessProxy mode launches the kernel as a *managed resource* within Yarn as noted above.
+##### YarnClusterProcessProxy
+YarnClusterProcessProxy mode launches the kernel as a *managed resource* within YARN as noted above.
 This launch mode requires that the command-line option `--EnterpriseGatewayApp.yarn_endpoint` be provided
 or the environment variable `EG_YARN_ENDPOINT` be defined.  If neither value exists, the default
 value of `http://localhost:8088/ws/v1/cluster` will be used.
 
-###### DistributedProcessProxy
+##### DistributedProcessProxy
 DistributedProcessProxy provides for a simple, round-robin remoting mechanism where each successive
 kernel is launched on a different host.  It requires that **each of the kernelspec files reside in
 the same path on each node and that password-less ssh has been established between nodes**.
 
-When launched, the kernel runs as a Yarn *client* - meaning that the kernel process itself is
-not managed by the Yarn resource manager.  This mode allows for the distribution of kernel
+When launched, the kernel runs as a YARN *client* - meaning that the kernel process itself is
+not managed by the YARN resource manager.  This mode allows for the distribution of kernel
 (spark driver) processes across the cluster.
 
 To use this form of distribution, the command-line option `--EnterpriseGatewayApp.remote_hosts=`
@@ -312,9 +309,9 @@ else
 fi
 ```
 
-#### Connecting a Notebook Client to Enterprise Gateway
+### Connecting a Notebook Client to Enterprise Gateway
 [NB2KG](https://github.com/jupyter/kernel_gateway_demos/tree/master/nb2kg) is used to connect from a
-local desktop or laptop to the Enterprise Gateway instance on the Yarn cluster. The most convenient
+local desktop or laptop to the Enterprise Gateway instance on the YARN cluster. The most convenient
 way to use a pre-configured installation of NB2KG would be using the Docker image
 [biginsights/jupyter-nb-nb2kg:dev](https://hub.docker.com/r/biginsights/jupyter-nb-nb2kg/). Replace
 the `<ENTERPRISE_GATEWAY_HOST_IP>` in the command below:

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -1,47 +1,60 @@
 ## Troubleshooting
 
-### I'm trying to launch a (Python/Scala/R) kernel in Yarn Cluster Mode but it failed with a "Kernel error" and State: 'FAILED'.  
+- **I'm trying to launch a (Python/Scala/R) kernel in YARN Cluster Mode but it failed with 
+a "Kernel error" and State: 'FAILED'.**
 
-1. Check the output from Enterprise Gateway for an error message.  If an applicationId was generated, make a note of it.  For example, you can locate the applicationId application_1506552273380_0011 from the following snippet of message:
+    1. Check the output from Enterprise Gateway for an error message.  If an applicationId was 
+    generated, make a note of it.  For example, you can locate the applicationId 
+    `application_1506552273380_0011` from the following snippet of message:
+        ```
+        [D 2017-09-28 17:13:22.675 EnterpriseGatewayApp] 13: State: 'ACCEPTED', Host: 'burna2.yourcompany.com', KernelID: '28a5e827-4676-4415-bbfc-ac30a0dcc4c3', ApplicationID: 'application_1506552273380_0011'
+        17/09/28 17:13:22 INFO YarnClientImpl: Submitted application application_1506552273380_0011
+        17/09/28 17:13:22 INFO Client: Application report for application_1506552273380_0011 (state: ACCEPTED)
+        17/09/28 17:13:22 INFO Client: 
+            client token: N/A
+            diagnostics: AM container is launched, waiting for AM container to Register with RM
+            ApplicationMaster host: N/A
+            ApplicationMaster RPC port: -1
+            queue: default
+            start time: 1506644002471
+            final status: UNDEFINED
+            tracking URL: http://burna1.yourcompany.com:8088/proxy/application_1506552273380_0011/
+        ```
+    2. Lookup the YARN log for that applicationId in the YARN ResourceManager UI: ![YARN ResourceManager UI](images/yarnui.jpg)
+    3. Drill down from the applicationId to find logs for the failed attempts and take appropriate
+     actions. For example, for the error below, 
+        ```
+        Traceback (most recent call last):
+         File "launch_ipykernel.py", line 7, in <module>
+           from ipython_genutils.py3compat import str_to_bytes
+         ImportError: No module named ipython_genutils.py3compat
+        ```
+        Simply running "pip install ipython_genutils" should fix the problem.  If Anaconda is 
+        installed, make sure the environment variable for Python, i.e. `PYSPARK_PYTHON`, is 
+        properly configured in the kernelspec and matches the actual Anaconda installation 
+        directory.   
+
+
+
+- **I'm trying to launch a (Python/Scala/R) kernel in YARN Client Mode but it failed with 
+a "Kernel error" and an AuthenticationException.**
     ```
-    [D 2017-09-28 17:13:22.675 EnterpriseGatewayApp] 13: State: 'ACCEPTED', Host: 'burna2.yourcompany.com', KernelID: '28a5e827-4676-4415-bbfc-ac30a0dcc4c3', ApplicationID: 'application_1506552273380_0011'
-    17/09/28 17:13:22 INFO YarnClientImpl: Submitted application application_1506552273380_0011
-    17/09/28 17:13:22 INFO Client: Application report for application_1506552273380_0011 (state: ACCEPTED)
-    17/09/28 17:13:22 INFO Client: 
-        client token: N/A
-        diagnostics: AM container is launched, waiting for AM container to Register with RM
-        ApplicationMaster host: N/A
-        ApplicationMaster RPC port: -1
-        queue: default
-        start time: 1506644002471
-        final status: UNDEFINED
-        tracking URL: http://burna1.yourcompany.com:8088/proxy/application_1506552273380_0011/
+    [E 2017-09-29 11:13:23.277 EnterpriseGatewayApp] Exception 'AuthenticationException' occurred 
+    when creating a SSHClient connecting to '172.xx.xxx.xxx' with user 'elyra', 
+    message='Authentication failed.'.
     ```
-2. Lookup the Yarn log for that applicationId in the Yarn ResourceManager UI:
-    ![Yarn ResourceManager UI](images/yarnui.jpg)
-3. Drill down from the applicationId to find logs for the failed attempts and take appropriate actions. For example, for the error below, 
-    ```
-    Traceback (most recent call last):
-     File "launch_ipykernel.py", line 7, in <module>
-       from ipython_genutils.py3compat import str_to_bytes
-     ImportError: No module named ipython_genutils.py3compat
-    ```
-    Simply running "pip install ipython_genutils" should fix the problem.  If Anaconda is installed, make sure the environment variable for Python, i.e. `PYSPARK_PYTHON`, is properly configured in the kernelspec and matches the actual Anaconda installation directory.   
-
-
-
-
-### I'm trying to launch a (Python/Scala/R) kernel in Yarn Client Mode but it failed with a "Kernel error" and an AuthenticationException:
-
-```
-[E 2017-09-29 11:13:23.277 EnterpriseGatewayApp] Exception 'AuthenticationException' occurred 
-when creating a SSHClient connecting to '172.xx.xxx.xxx' with user 'elyra', 
-message='Authentication failed.'.
-```
-
-This error indicates that the password-less ssh may not be properly configured.  Password-less ssh needs to be configured on the node that the Enterprise Gateway is running on to all other worker nodes.
-
-In general, you can look for more information in the proxy launch log for Yarn Client kernels.  The default location is /tmp/jeg_proxy_launch.log and it can be configured using the environment variable `EG_PROXY_LAUNCH_LOG` during Enterprise Gateway start up.  See [Starting Enterprise Gateway](getting-started.html#starting-enterprise-gateway) for an example of starting the Enterprise Gateway from a script and [Supported Environment Variables](config-options.html#supported-environment-variables-with-default-values) for a list of configurable environment variables.   
+    
+    This error indicates that the password-less ssh may not be properly configured.  Password-less 
+    ssh needs to be configured on the node that the Enterprise Gateway is running on to all other 
+    worker nodes.
+    
+    In general, you can look for more information in the proxy launch log for YARN Client 
+    kernels.  The default location is /tmp/jeg_proxy_launch.log and it can be configured 
+    using the environment variable `EG_PROXY_LAUNCH_LOG` during Enterprise Gateway start up. 
+    See [Starting Enterprise Gateway](getting-started.html#starting-enterprise-gateway) for an 
+    example of starting the Enterprise Gateway from a script and 
+    [Supported Environment Variables](config-options.html#supported-environment-variables) 
+    for a list of configurable environment variables.   
 
 
 

--- a/docs/source/uses.md
+++ b/docs/source/uses.md
@@ -4,16 +4,16 @@ Jupyter Enterprise Gateway addresses specific use cases for different personas. 
 
 - **As an administrator**,  I want to fix the bottleneck on the Kernel Gateway server due to large number of kernels
 running on it and the size of each kernel (spark driver) process, by deploying the Enterprise Gateway, such that
-kernels can be launched as managed resources within Yarn, distributing the resource-intensive driver processes across
-the Yarn cluster, while still allowing the data analysts to leverage the compute power of a large Yarn cluster.
+kernels can be launched as managed resources within YARN, distributing the resource-intensive driver processes across
+the YARN cluster, while still allowing the data analysts to leverage the compute power of a large YARN cluster.
 
 - **As an administrator**, I want to have some user isolation such that user processes are protected against each
 other and user can preserve and leverage their own environment, i.e. libraries and/or packages.
 
 - **As a data scientist**, I want to run my notebook using the Enterprise Gateway such that I can free up resources
-on my own laptop and leverage my company's large Yarn cluster to run my compute-intensive jobs.
+on my own laptop and leverage my company's large YARN cluster to run my compute-intensive jobs.
 
 - **As a solution architect**, I want to explore supporting a different resource manager with Enterprise Gateway,
-i.e. Kubernetes, by extending and implementing a new ProcessProxy class, i.e. K8ProcessProxy, such that I can easily
+e.g. Kubernetes, by extending and implementing a new ProcessProxy class, e.g. K8ProcessProxy, such that I can easily
 take advantage of specific functionality provided by the resource manager.
 


### PR DESCRIPTION
Removed redundant headers.
Upcase YARN where appropriate.
Fix up header levels for better left-hand-side navigation.
Add YarnClusterProcessProxy and DistributedProcessProxy sections to
architecture page.
Removed headers on troubleshooting scenarios so they don't appear
in LHS (too long).